### PR TITLE
fix syntax error in readme for site extension script

### DIFF
--- a/technologies/azure/automate-appservice-siteextension-setup/README.md
+++ b/technologies/azure/automate-appservice-siteextension-setup/README.md
@@ -33,7 +33,7 @@ Before executing the script, make sure you are signed-in with Azure CLI. For mor
 ### Example 
 
 ``` 
-./automate-siteextension.ps1 -subscription "Demo" -resourceGroup "MyAppServiceGroup" -appName "MyApp" -environmentId ="XXXXXX" -apiToken ="XXXX"
+./automate-siteextension.ps1 -subscription "Demo" -resourceGroup "MyAppServiceGroup" -appName "MyApp" -environmentId "XXXXXX" -apiToken "XXXX"
 ``` 
 
 


### PR DESCRIPTION
Fix syntax error in the readme for Dynatrace extension PowerShell script 