### PR TITLE
CLUSTER-8012 upload logs script

### DIFF
--- a/product/logging/upload_logs.py
+++ b/product/logging/upload_logs.py
@@ -1,0 +1,140 @@
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+from os import getcwd
+from typing import MutableSequence
+
+import requests
+
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def partition_for_api(input_list: MutableSequence[MutableSequence[any]]) -> MutableSequence:
+    result: MutableSequence[MutableSequence] = []
+    for sublist in input_list:
+        # every request can only hold 50.000 logs and be 5 MB at max
+        if len(sublist) > 50000 or len(json.dumps(sublist).encode("utf-8")) > 5 * 1024 * 1024:
+            # to do this, split the list in 2 pieces to make it recursively smaller until it works
+            split_index = int(len(sublist) / 2)
+            # append all resulting lists to result
+            [result.append(sl) for sl in partition_for_api([sublist[:split_index]])]
+            [result.append(sl) for sl in partition_for_api([sublist[split_index:]])]
+        else:
+            result.append(sublist)
+    return result
+
+
+# these need to be hardcoded here to find the index of the log level to get that + tenant information & class name
+# (logs can optionally have the timezone and/or trace information before the log level,
+# making it impossible to hardcode the index)
+LOG_LEVELS = ["TRACE", "DEBUG", "INFO", "WARN", "WARNING", "ERROR", "SEVERE", "FATAL"]
+
+
+def main():
+    argument_parser = argparse.ArgumentParser(
+        prog='Log Uploader',
+        description="Uploads managed logs to a SaaS environment"
+    )
+    argument_parser.add_argument("environment_url", help="URL of the environment")
+    argument_parser.add_argument("api_token", help="Required Scope: logs.ingests")
+    argument_parser.add_argument("file_pattern",
+                                 help="Specify the file selector. Wildcard (*) is supported.",
+                                 default="*.log")
+
+    argument_parser.add_argument("--timezone", "--tz",
+                                 help="Timezone of the log total_lines as defined by RFC 3339",
+                                 required=True)
+
+    arguments = argument_parser.parse_args()
+
+    environment_url = arguments.environment_url
+    api_token = arguments.api_token
+
+    file_pattern = arguments.file_pattern
+    timezone: str = arguments.timezone
+
+    total_lines = 0
+    result = []
+    for file in glob.glob(file_pattern, recursive=True):
+        # if not os.path.isfile(file):
+        # continue
+
+        handle = open(file, "r")
+        for line in handle:
+            # example log:
+            # 2023-08-07 13:46:31 INFO    [0] [MyClass] Hello World!
+            # 2023-08-10 10:23:51 UTC SEVERE    [0] [MyClass] Hello World!
+            # 2023-08-10 10:23:51 UTC [!dt dt.trace_id=...,dt.trace_sampled=true] INFO    [0] [MyClass] Hello World!
+
+            # split by multiple spaces as well because there are 4 after the log level
+            parts = re.split(r"\s+", line)
+
+            # position of the log level can vary (see above)
+            log_level = None
+            log_level_location = None
+            for index in range(2, 6):
+                part = parts[index]
+                if part in LOG_LEVELS:
+                    log_level_location = index
+                    log_level = part
+                    break
+
+            if log_level is None or log_level_location is None:
+                eprint("Couldn't parse", line)
+                continue
+
+            tenant_id = parts[log_level_location + 1]
+            tenant_id = tenant_id[1:len(tenant_id) - 1]
+
+            timestamp: str = parts[0] + "T" + parts[1] + timezone
+
+            result.append({
+                # relative path, starting from the current working directory
+                # this allows logfiles to be called after their file name rather than the absolute path
+                "log.source": os.path.relpath(file, getcwd()),
+                "content": line,
+                "timestamp": timestamp,
+                "level": log_level,
+                "dt.tenant.id": tenant_id
+            })
+            total_lines += 1
+
+    # a single request can only hold so much, therefore, we chunk the list into pieces the API can handle
+    lists = partition_for_api([result])
+
+    error_count = 0
+    success_count = 0
+    for sublist in lists:
+        response = requests.post(url=environment_url + "/api/v2/logs/ingest",
+                                 headers={
+                                     "Authorization": "Api-Token " + api_token,
+                                     "Content-Type": "application/json; charset=utf-8"
+                                 },
+                                 json=sublist
+                                 )
+        print(response.status_code, response.content.decode("utf-8"))
+        match response.status_code:
+            # complete success, all items ingested
+            case 204:
+                success_count += len(sublist)
+            # partial suggest => some lines ingested, others not
+            case 200:
+                # parse failure count from a response like this:
+                # {"success":{"code":200,"message":"1531 events were not ingested because of timestamp out of correct time range."}}
+                message: str = json.loads(response.content)["success"]["message"]
+                errors = int(message.split(" ")[0])
+                success_count += len(sublist) - errors
+            # all logs are outside the time range
+            case 400:
+                error_count += len(sublist)
+
+    print("Successfully ingested", success_count, "logs, failed to ingest", error_count, "lines.")
+
+
+if __name__ == "__main__":
+    main()

--- a/product/logging/upload_logs.py
+++ b/product/logging/upload_logs.py
@@ -41,7 +41,7 @@ def main():
         description="Uploads managed logs to a SaaS environment"
     )
     argument_parser.add_argument("environment_url", help="URL of the environment")
-    argument_parser.add_argument("api_token", help="Required Scope: logs.ingests")
+    argument_parser.add_argument("api_token", help="Required Scope: logs.ingest")
     argument_parser.add_argument("file_pattern",
                                  help="Specify the file selector. Wildcard (*) is supported.",
                                  default="*.log")

--- a/product/logging/upload_logs.py
+++ b/product/logging/upload_logs.py
@@ -49,6 +49,10 @@ def main():
     argument_parser.add_argument("--timezone", "--tz",
                                  help="Timezone of the log total_lines as defined by RFC 3339",
                                  required=True)
+    argument_parser.add_argument("--no-traces", "--remove-traces",
+                                 help="Removes trace information from lines before uploading",
+                                 default=False,
+                                 action="store_true")
 
     arguments = argument_parser.parse_args()
 
@@ -57,6 +61,7 @@ def main():
 
     file_pattern = arguments.file_pattern
     timezone: str = arguments.timezone
+    no_traces: bool = arguments.no_traces
 
     total_lines = 0
     result = []
@@ -70,6 +75,9 @@ def main():
             # 2023-08-07 13:46:31 INFO    [0] [MyClass] Hello World!
             # 2023-08-10 10:23:51 UTC SEVERE    [0] [MyClass] Hello World!
             # 2023-08-10 10:23:51 UTC [!dt dt.trace_id=...,dt.trace_sampled=true] INFO    [0] [MyClass] Hello World!
+
+            if no_traces:
+                line = re.sub(r"(\[!dt dt\.trace.*?\]\s)", "", line)
 
             # split by multiple spaces as well because there are 4 after the log level
             parts = re.split(r"\s+", line)


### PR DESCRIPTION
The `upload_logs.py` script can be used to upload log files of managed clusters to a SaaS environment.
This is particularly useful in support cases where, after the reporter ingested them using the script, the support agent can query the logs with DQL.

Requested in CLUSTER-8012