### PR TITLE
Ignore entity types for which the management zone selector is not applicable

### DIFF
--- a/api/ddu/management-zone-calculation/dduConsumptionPerMZ.py
+++ b/api/ddu/management-zone-calculation/dduConsumptionPerMZ.py
@@ -111,6 +111,13 @@ for managementZoneIndex, managementZone in (
             ),
             headers={"Authorization": "Api-Token " + API_TOKEN},
         )
+        if response.status_code == 400 and "not applicable for type" in response.text:
+            continue
+        if response.status_code == 503:
+            print(f"Encountered 503 for "
+                  f"{allManagemementZones[managementZoneIndex]['id']} - {allEntityTypes[entityTypeIndex]['type']} "
+                  f"result will be incomplete.")
+            continue
         response.raise_for_status()
         # print("Waiting for ", 60 / MAX_REQUESTS_PER_MINUTE, " seconds")
         time.sleep(60 / MAX_REQUESTS_PER_MINUTE)


### PR DESCRIPTION
The api changed so that invalid type-to-entitySelector fail with a status_code of 400. This fix is a bit of a workaround and simply ignores those types, as no management-zone-related usage can be extracted from them

Additionally, 503 are also ignored and logged instead.